### PR TITLE
Fix deprecated now

### DIFF
--- a/doc/examples/sample_mc.erl
+++ b/doc/examples/sample_mc.erl
@@ -106,7 +106,7 @@ success() ->
 %%% INIT/TERMINATE EXPORTS
 %%%-----------------------------------------------------------------------------
 init([Silent]) ->
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     {ok, #st{silent = Silent}}.
 

--- a/doc/smpp_disk_log_hlr.ndoc
+++ b/doc/smpp_disk_log_hlr.ndoc
@@ -19,8 +19,8 @@ This module implements the ``gen_event`` behaviour.
 = DESCRIPTION =
 
 The ``disk_log_hlr`` stores SMPP PDUs on disk in tuples with the format
-``{Now, Format(Pdu)}``. ``Now`` is the timestamp as returned by the
-BIF ``now()``. ``Pdu`` is the SMPP PDU in binary format and ``Format`` is the
+``{Timestamp, Format(Pdu)}``. ``Now`` is the timestamp as returned by the
+BIF ``erlang:timestamp()``. ``Pdu`` is the SMPP PDU in binary format and ``Format`` is the
 formatting fun.
 
 The format of the term stored by the disk log can be redefined using a custom

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [warnings_as_errors, debug_info]}.
 
 {deps, [{common_lib, "3.3.4",
-         {git, "git://github.com/iamaleksey/common_lib.git", {tag, "3.3.4"}}}]}.
+         {git, "git://github.com/iamaleksey/common_lib.git", {tag, "3.3.5"}}}]}.
 
 {erl_first_files, ["src/gen_esme_session.erl",
                    "src/gen_mc_session.erl",

--- a/src/smpp_disk_log_hlr.erl
+++ b/src/smpp_disk_log_hlr.erl
@@ -141,7 +141,7 @@ handle_call(Req, St) ->
 handle_event({pdu, Pdu}, St) ->
     case catch (St#st.filter)(Pdu) of
         true ->
-            disk_log:alog(St#st.name, {now(), (St#st.format)(Pdu)});
+            disk_log:alog(St#st.name, {erlang:timestamp(), (St#st.format)(Pdu)});
         _Otherwise ->
             ok
     end,
@@ -180,5 +180,3 @@ init_st(Args) ->
 
 merge_args(Args1, Args2) ->
     cl_lists:ukeymerge(1, lists:keysort(1, Args1), lists:keysort(1, Args2)).
-
-

--- a/src/smpp_param.hrl
+++ b/src/smpp_param.hrl
@@ -159,7 +159,7 @@
 %% destination_addr
 %%
 %% %@doc Specifies the destination SME address.  For mobile terminated
-%% messages, this is the directory number of the recipient MS.  IP addresses ็
+%% messages, this is the directory number of the recipient MS.  IP addresses รง
 %% are specified in "aaa.bbb.ccc.ddd" notation.  C-Octet String, Var. max 21
 %% octets.
 %% %@end

--- a/src/smpp_session.erl
+++ b/src/smpp_session.erl
@@ -70,7 +70,7 @@
 %% instant congestion state value is calculated.  Notice this value cannot be
 %% greater than 99.
 congestion(CongestionSt, WaitTime, Timestamp) ->
-    case (timer:now_diff(now(), Timestamp) div (WaitTime + 1)) * 85 of
+    case (timer:now_diff(erlang:timestamp(), Timestamp) div (WaitTime + 1)) * 85 of
         Val when Val < 1 ->
             0;
         Val when Val > 99 ->  % Out of bounds
@@ -161,11 +161,11 @@ wait_recv(Pid, Sock, Log) ->
 
 
 recv_loop(Pid, Sock, Buffer, Log) ->
-    Timestamp = now(),
+    Timestamp = erlang:timestamp(),
     inet:setopts(Sock, [{active, once}]),
     receive
         {tcp, Sock, Input} ->
-            L = timer:now_diff(now(), Timestamp),
+            L = timer:now_diff(erlang:timestamp(), Timestamp),
             B = handle_input(Pid, list_to_binary([Buffer, Input]), L, 1, Log),
             ?MODULE:recv_loop(Pid, Sock, B, Log);
         {tcp_closed, Sock} ->
@@ -223,7 +223,7 @@ handle_accept(Pid, Sock) ->
 
 
 handle_input(Pid, <<CmdLen:32, Rest/binary>> = Buffer, Lapse, N, Log) ->
-    Now = now(), % PDU received.  PDU handling starts now!
+    Now = erlang:timestamp(), % PDU received.  PDU handling starts now!
     Len = CmdLen - 4,
     case Rest of
         <<PduRest:Len/binary-unit:8, NextPdus/binary>> ->

--- a/test/gen_esme_SUITE.erl
+++ b/test/gen_esme_SUITE.erl
@@ -70,7 +70,7 @@ suite() ->
 %% @end
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     application:start(common_lib),
     dbg:tracer(),

--- a/test/gen_mc_SUITE.erl
+++ b/test/gen_mc_SUITE.erl
@@ -63,7 +63,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     application:start(common_lib),
     dbg:tracer(),

--- a/test/log_SUITE.erl
+++ b/test/log_SUITE.erl
@@ -58,7 +58,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     dbg:tracer(),
     dbg:p(all, [c, sos, sol]),

--- a/test/operation_SUITE.erl
+++ b/test/operation_SUITE.erl
@@ -60,7 +60,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     dbg:tracer(),
     dbg:p(all, [c, sos, sol]),

--- a/test/test_mc.erl
+++ b/test/test_mc.erl
@@ -201,7 +201,7 @@ success() ->
 %%% INIT/TERMINATE EXPORTS
 %%%-----------------------------------------------------------------------------
 init([Silent]) ->
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     {ok, #st{silent = Silent}}.
 


### PR DESCRIPTION
The previously widely used now/0 function has
been deprecated in favor of different functions
for specific tasks. These are things like creating
monotonically ordered integers, getting timestamps,
performing diffs on timestamps, etc.

Reference page for deprecation purpose:
http://www.erlang.org/doc/apps/erts/time_correction.html

Bump version to 3.3.5

[matching PR for common_lib here](https://github.com/iamaleksey/common_lib/pull/1)